### PR TITLE
fix: navigate always to base url

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,27 +1,27 @@
-// import { getPermalink, getBlogPermalink, } from './utils/permalinks';
+import { getPermalink } from './utils/permalinks';
 // import { getPermalink, getBlogPermalink, getAsset } from './utils/permalinks';
 
 export const headerData = {
   links: [
     {
       text: "The Word",
-      href: "word",
+      href: getPermalink("word"),
     },
     {
       text: "Prayer",
-      href: "prayer",
+      href: getPermalink("prayer"),
     },
     {
       text: "Devotions",
-      href: "devotions",
+      href: getPermalink("devotions"),
     },
     {
       text: "Witnesses",
-      href: "witnesses",
+      href: getPermalink("witnesses"),
     },
     {
       text: "The Five Fold",
-      href: "fivefold",
+      href: getPermalink("fivefold"),
     },
     // {
     //   text: 'Home',


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the `navigation.js` file to use the `getPermalink` function from `permalinks.js` for generating the hrefs of the header links.
> 
> ## What changed
> The hardcoded hrefs for the header links in `navigation.js` have been replaced with calls to the `getPermalink` function. This function generates permalinks based on the provided string argument.
> 
> ## How to test
> To test these changes, navigate to the different sections of the website using the header links. The URLs in the address bar should match the expected permalinks for each section.
> 
> ## Why make this change
> This change ensures that the website's navigation links are generated dynamically, making it easier to maintain and update the site structure in the future. It also ensures that the permalinks are consistent across the site, improving the user experience and SEO.
</details>