### PR TITLE
fix: Content link text break-all

### DIFF
--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -108,7 +108,7 @@ const {
             bottom.links.map(({ title, link }) => (
               <p class={twMerge("pt-4 text-xl")}>
                 {title}:
-                <a class="hover:underline" href={link} target="_blank">
+                <a class="hover:underline break-all" href={link} target="_blank">
                   {link}
                 </a>
               </p>


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the CSS class of the anchor tag in the `Content.astro` component to include `break-all` to ensure long URLs do not overflow their container.
> 
> ## What changed
> The CSS class of the anchor tag in the `Content.astro` component was changed from `hover:underline` to `hover:underline break-all`. This change ensures that long URLs will break onto the next line instead of overflowing their container.
> 
> ```diff
> -                <a class="hover:underline" href={link} target="_blank">
> +                <a class="hover:underline break-all" href={link} target="_blank">
> ```
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Navigate to a page that uses the `Content.astro` component.
> 3. Add a long URL to the `bottom.links` array and observe that it breaks onto the next line instead of overflowing its container.
> 
> ## Why make this change
> This change improves the user experience by ensuring that long URLs do not overflow their container, which could cause layout issues or make the URL difficult to read.
</details>