### PR TITLE
fix: church breaklines

### DIFF
--- a/src/components/ui/ItemGrid2.astro
+++ b/src/components/ui/ItemGrid2.astro
@@ -39,7 +39,7 @@ const {
           )}
           <div class={twMerge('text-xl font-bold', titleClass, itemClasses?.title)}>{title}</div>
           {description && link ? (
-            <a class={twMerge('text-muted mt-2 hover:underline break-all', itemClasses?.description)} set:html={description} href={description} target="_blank" />
+            <a class={twMerge('text-muted mt-2 hover:underline break-all', itemClasses?.description)} set:html={description} href={description.toString()} target="_blank" />
           ) : (
             description && (
               <p

--- a/src/components/ui/Timeline.astro
+++ b/src/components/ui/Timeline.astro
@@ -23,60 +23,39 @@ const {
 {
   items && items.length && (
     <div class={containerClass}>
-      {items.map(
-        (
-          { title, description, icon, classes: itemClasses = {} },
-          index = 0
-        ) => (
-          <div class={twMerge("flex", panelClass, itemClasses?.panel)}>
-            <div class="flex flex-col items-center mr-4 rtl:mr-0 rtl:ml-4">
-              <div>
-                <div class="flex items-center justify-center">
-                  {(icon || defaultIcon) && (
-                    <Icon
-                      name={icon || defaultIcon}
-                      class={twMerge(
-                        "w-10 h-10 p-2 rounded-full border-2",
-                        defaultIconClass,
-                        itemClasses?.icon
-                      )}
-                    />
-                  )}
-                </div>
+      {items.map(({ title, description, icon, classes: itemClasses = {} }, index = 0) => (
+        <div class={twMerge("flex", panelClass, itemClasses?.panel)}>
+          <div class="flex flex-col items-center mr-4 rtl:mr-0 rtl:ml-4">
+            <div>
+              <div class="flex items-center justify-center">
+                {(icon || defaultIcon) && (
+                  <Icon
+                    name={icon || defaultIcon}
+                    class={twMerge("w-10 h-10 p-2 rounded-full border-2", defaultIconClass, itemClasses?.icon)}
+                  />
+                )}
               </div>
-              {index !== items.length - 1 && (
-                <div class="w-px h-full bg-black/10 dark:bg-slate-400/50" />
-              )}
             </div>
-            <div
-              class={`pt-1 ${
-                index !== items.length - 1 ? "pb-8" : ""
-              }`}
-            >
-              {title && (
-                <p
-                  class={twMerge(
-                    "text-xl font-bold",
-                    titleClass,
-                    itemClasses?.title
-                  )}
-                  set:html={title}
-                />
-              )}
-              {description && (
-                <p
-                  class={twMerge(
-                    "text-muted mt-2 whitespace-pre-line",
-                    descriptionClass,
-                    itemClasses?.description
-                  )}
-                  set:html={description}
-                />
-              )}
-            </div>
+            {index !== items.length - 1 && <div class="w-px h-full bg-black/10 dark:bg-slate-400/50" />}
           </div>
-        )
-      )}
+          <div class={`pt-1 ${index !== items.length - 1 ? "pb-8" : ""}`}>
+            {title && <p class={twMerge("text-xl font-bold", titleClass, itemClasses?.title)} set:html={title} />}
+            {description && Array.isArray(description)
+              ? description.map((text) => (
+                  <p
+                    class={twMerge("text-muted mt-2", descriptionClass, itemClasses?.description)}
+                    set:html={text}
+                  />
+                ))
+              : description && (
+                  <p
+                    class={twMerge("text-muted mt-2", descriptionClass, itemClasses?.description)}
+                    set:html={description}
+                  />
+                )}
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,11 +1,8 @@
 site:
   name: FLAME the FREEZE
-  site: 'https://flamethefreeze.vercel.app'
+  site: 'https://flamethefreeze.com'
   base: '/'
   trailingSlash: false
-
-  googleSiteVerificationId: null
-  # googleSiteVerificationId: orcPxI47GSa-cRvY11tUe6iGg2IO_RPvnA1q95iEM3M
 
 # Default SEO metadata
 metadata:
@@ -60,11 +57,6 @@ i18n:
 #       pathname: 'tag' # Tag main path /tag/some-tag, you can change this to "topics" (/topics/some-category)
 #       robots:
 #         index: false
-
-analytics:
-  vendors:
-    googleAnalytics:
-      id: null # or "G-XXXXXXXXXX"
 
 ui:
   theme: 'dark' # Values: "system" | "light" | "dark" | "light:only" | "dark:only"

--- a/src/pages/church.astro
+++ b/src/pages/church.astro
@@ -19,15 +19,16 @@ const metadata = {
     <Fragment slot="subtitle">
       There are
       <span class="font-semibold"> so many</span>
-       churches and denominations today that you get your head spinning trying to figure out what is genuine. Does the true church of <span class="text-accent highlight font-semibold">Jesus Christ</span> exist
-      today? Can you identify it?
+       churches and denominations today that you get your head spinning trying to figure out what is genuine. Does the
+      true church of <span class="text-accent highlight font-semibold">Jesus Christ</span> exist today? Can you identify
+      it?
     </Fragment>
   </HeroText>
 
   <!-- Steps Widget ****************** -->
 
   <Steps
-    tagline="A guided to identify a true church"
+    tagline="A guide"
     title="The church to attend is where:"
     isReversed={true}
     items={[
@@ -51,27 +52,39 @@ const metadata = {
       },
       {
         title: "The love toward the world dies and love towards the things of the world dies 💔",
-        description:
-          "Love not the world, neither the things that are in the world. If any man love the world, the love of the Father is not in him. For all that is in the world, the lust of the flesh, and the lust of the eyes, and the pride of life, is not of the Father, but is of the world. 1 Joh 2:15,16 KJV. \n\nNothing in this world satisfies you anymore, you just want Jesus and more of Him. \n\nThat I may know him, and the power of his resurrection, and the fellowship of his sufferings, being made conformable unto his death. Phi 3:10 KJV. \n\nIf you have started to pray more, if you have started to read the Bible more, if you started to preach the gospel more, *then* you are in the right place. \n\nTherefore, my beloved brethren, be ye stedfast, unmoveable, always abounding in the work of the Lord, forasmuch as ye know that your labour is not in vain in the Lord. 1 Cor 15:58 KJV.  ",
+        description: [
+          "Love not the world, neither the things that are in the world. If any man love the world, the love of the Father is not in him. For all that is in the world, the lust of the flesh, and the lust of the eyes, and the pride of life, is not of the Father, but is of the world. 1 Joh 2:15,16 KJV.",
+          "Nothing in this world satisfies you anymore, you just want Jesus and more of Him.",
+          "That I may know him, and the power of his resurrection, and the fellowship of his sufferings, being made conformable unto his death. Phi 3:10 KJV.",
+          "If you have started to pray more, if you have started to read the Bible more, if you started to preach the gospel more, *then* you are in the right place.",
+          "Therefore, my beloved brethren, be ye stedfast, unmoveable, always abounding in the work of the Lord, forasmuch as ye know that your labour is not in vain in the Lord. 1 Cor 15:58 KJV.",
+        ],
         icon: "tabler:number-4",
       },
       {
         title:
           "Your passion to pray together and individually is kindled to full flame and just enlarges day by day. Wanting to pray hours and hours 🔥",
-        description:
-          "Now I beseech you, brethren, for the Lord Jesus Christ's sake, and for the love of the Spirit, that ye strive together with me in your prayers to God for me.Rom 15:30 KJV. \n\nHow alive a church is is noticed from its' prayer meeting directly. You want to know the state of the church, go to prayer meeting. If it is full of passion, fervency, heartfelt, Spirit and scripture filled prayers, then you are at the right place. If they pray for souls, agonize for dead churches, cry for the wayward, lay down in pain for the lost, travail for general revival, strive for the advancing of the gospel, and resist to blood against sin, *then* you are at the right place. If these are not found, the church has lost its first love and has a name but is dead. For out of the abundance of the heart the mouth speaketh. \n\nO generation of vipers, how can ye, being evil, speak good things? for out of the abundance of the heart the mouth speaketh. Mat 12:34 KJV",
+        description: [
+          "Now I beseech you, brethren, for the Lord Jesus Christ's sake, and for the love of the Spirit, that ye strive together with me in your prayers to God for me.Rom 15:30 KJV.",
+          "How alive a church is is noticed from its' prayer meeting directly. You want to know the state of the church, go to prayer meeting. If it is full of passion, fervency, heartfelt, Spirit and scripture filled prayers, then you are at the right place. If they pray for souls, agonize for dead churches, cry for the wayward, lay down in pain for the lost, travail for general revival, strive for the advancing of the gospel, and resist to blood against sin, *then* you are at the right place. If these are not found, the church has lost its first love and has a name but is dead. For out of the abundance of the heart the mouth speaketh.",
+          "O generation of vipers, how can ye, being evil, speak good things? for out of the abundance of the heart the mouth speaketh. Mat 12:34 KJV",
+        ],
         icon: "tabler:number-5",
       },
       {
         title: "You get more people saved 👥👥👥",
-        description:
-          "And Jesus came and spake unto them, saying, All power is given unto me in heaven and in earth. Go ye therefore, and teach all nations, baptizing them in the name of the Father, and of the Son, and of the Holy Ghost: Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you always, even unto the end of the world. Amen. Mat 28:18-20 KJV. \n\nAnd he said unto them, Go ye into all the world, and preach the gospel to every creature. Mark 16:15 KJV",
+        description: [
+          "And Jesus came and spake unto them, saying, All power is given unto me in heaven and in earth. Go ye therefore, and teach all nations, baptizing them in the name of the Father, and of the Son, and of the Holy Ghost: Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you always, even unto the end of the world. Amen. Mat 28:18-20 KJV.",
+          "And he said unto them, Go ye into all the world, and preach the gospel to every creature. Mark 16:15 KJV",
+        ],
         icon: "tabler:number-6",
       },
       {
         title: "Holiness is preached and is evident in the life of people 🛁🧼",
-        description:
-          "But as he which hath called you is holy, so be ye holy in all manner of conversation; Because it is written, Be ye holy; for I am holy. And if ye call on the Father, who without respect of persons judgeth according to every man's work, pass the time of your sojourning here in fear: Forasmuch as ye know that ye were not redeemed with corruptible things, as silver and gold, from your vain conversation received by tradition from your fathers; But with the precious blood of Christ, as of a lamb without blemish and without spot. 1 Pet 1:15-20 KJV. \n\nBeloved, now are we the sons of God, and it doth not yet appear what we shall be: but we know that, when he shall appear, we shall be like him; for we shall see him as he is. And every man that hath this hope in him purifieth himself, even as he is pure. 1 Joh 3:2,3 KJV.",
+        description: [
+          "But as he which hath called you is holy, so be ye holy in all manner of conversation; Because it is written, Be ye holy; for I am holy. And if ye call on the Father, who without respect of persons judgeth according to every man's work, pass the time of your sojourning here in fear: Forasmuch as ye know that ye were not redeemed with corruptible things, as silver and gold, from your vain conversation received by tradition from your fathers; But with the precious blood of Christ, as of a lamb without blemish and without spot. 1 Pet 1:15-20 KJV.",
+          "Beloved, now are we the sons of God, and it doth not yet appear what we shall be: but we know that, when he shall appear, we shall be like him; for we shall see him as he is. And every man that hath this hope in him purifieth himself, even as he is pure. 1 Joh 3:2,3 KJV.",
+        ],
         icon: "tabler:number-7",
       },
       {
@@ -83,14 +96,20 @@ const metadata = {
       {
         title:
           "Sin ceases from your life, you are released from your oppressions, the addictions are broken, sicknesses are healed, demons are being cast out, LIVES are being transformed by The Power of GOD! 💥",
-        description:
-          "And these signs shall follow them that believe; In my name shall they cast out devils; they shall speak with new tongues; They shall take up serpents; and if they drink any deadly thing, it shall not hurt them; they shall lay hands on the sick, and they shall recover. Mark 16:17,18 KJV. \n\nThe Spirit of the Lord is upon me, because he hath anointed me to preach the gospel to the poor; he hath sent me to heal the brokenhearted, to preach deliverance to the captives, and recovering of sight to the blind, to set at liberty them that are bruised. Luke 4:18 KJV. \n\nHow God anointed Jesus of Nazareth with the Holy Ghost and with power: who went about doing good, and healing all that were oppressed of the devil; for God was with him. Acts 10:38 KJV. \n\nAnd my speech and my preaching was not with enticing words of man's wisdom, but in demonstration of the Spirit and of power: That your faith should not stand in the wisdom of men, but in the power of God. 1 Cor 2:4,5 KJV.",
+        description: [
+          "And these signs shall follow them that believe; In my name shall they cast out devils; they shall speak with new tongues; They shall take up serpents; and if they drink any deadly thing, it shall not hurt them; they shall lay hands on the sick, and they shall recover. Mark 16:17,18 KJV.",
+          "The Spirit of the Lord is upon me, because he hath anointed me to preach the gospel to the poor; he hath sent me to heal the brokenhearted, to preach deliverance to the captives, and recovering of sight to the blind, to set at liberty them that are bruised. Luke 4:18 KJV.",
+          "How God anointed Jesus of Nazareth with the Holy Ghost and with power: who went about doing good, and healing all that were oppressed of the devil; for God was with him. Acts 10:38 KJV.",
+          "And my speech and my preaching was not with enticing words of man's wisdom, but in demonstration of the Spirit and of power: That your faith should not stand in the wisdom of men, but in the power of God. 1 Cor 2:4,5 KJV.",
+        ],
         icon: "tabler:number-9",
       },
       {
         title: "There is liberty, righteousness, joy and peace in the Holy Ghost 🗽",
-        description:
-          "For the kingdom of God is not meat and drink; but righteousness, and peace, and joy in the Holy Ghost. Rom 14:17 KJV. \n\nNow the Lord is that Spirit: and where the Spirit of the Lord is, there is liberty. 2 Cor 3:17 KJV.",
+        description: [
+          "For the kingdom of God is not meat and drink; but righteousness, and peace, and joy in the Holy Ghost. Rom 14:17 KJV.",
+          "Now the Lord is that Spirit: and where the Spirit of the Lord is, there is liberty. 2 Cor 3:17 KJV.",
+        ],
         icon: "tabler:check",
       },
     ]}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -130,7 +130,7 @@ export interface Stat {
 
 export interface Item {
   title?: string;
-  description?: string;
+  description?: string | string[];
   icon?: string;
   classes?: Record<string, string>;
   callToAction?: CallToAction;


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request includes changes made to two files: ItemGrid2.astro and Timeline.astro. In ItemGrid2.astro, the href attribute of an anchor tag is modified to convert the description into a string before setting it as the href value. In Timeline.astro, multiple changes are made, but the details are not provided.
> 
> ## What changed
> ### ItemGrid2.astro
> - Modified the href attribute of an anchor tag to convert the description into a string before setting it as the href value.
> 
> ### Timeline.astro
> - Multiple changes made, but details not provided.
> 
> ## How to test
> No specific testing instructions provided.
> 
> ## Why make this change
> The reasons for making these changes are not provided.
</details>