### PR TITLE
change: church up, lang picker (wip)

### DIFF
--- a/src/components/LanguagePicker.astro
+++ b/src/components/LanguagePicker.astro
@@ -1,0 +1,10 @@
+---
+import { languages } from './ui';
+---
+<ul>
+  {Object.entries(languages).map(([lang, label]) => (
+    <li>
+      <a href={`/${lang}/`}>{label}</a>
+    </li>
+  ))}
+</ul>

--- a/src/components/ui.ts
+++ b/src/components/ui.ts
@@ -1,0 +1,20 @@
+export const languages = {
+  en: 'English',
+  fi: 'Finnish',
+};
+
+export const defaultLang = 'en';
+
+export const ui = {
+  en: {
+    'nav.home': 'Home',
+    'nav.about': 'About',
+    'nav.twitter': 'Twitter',
+  },
+  fi: {
+    'nav.home': 'Accueil',
+    'nav.about': 'À propos',
+  },
+} as const;
+
+export const showDefaultLang = false;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,20 @@
+
+ import { ui, defaultLang, showDefaultLang } from './ui';
+
+export function getLangFromUrl(url: URL) {
+  const [, lang] = url.pathname.split('/');
+  if (lang in ui) return lang as keyof typeof ui;
+  return defaultLang;
+}
+
+export function useTranslations(lang: keyof typeof ui) {
+  return function t(key: keyof typeof ui[typeof defaultLang]) {
+    return ui[lang][key] || ui[defaultLang][key];
+  }
+}
+
+ export function useTranslatedPath(lang: keyof typeof ui) {
+   return function translatePath(path: string, l: string = lang) {
+     return !showDefaultLang && l === defaultLang ? path : `/${l}${path}`
+   }
+ }

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -8,6 +8,7 @@ import Button from "~/components/ui/Button.astro"
 import { getHomePermalink } from "~/utils/permalinks";
 import { trimSlash, getAsset } from "~/utils/permalinks";
 import type { CallToAction } from "~/types";
+// import LanguagePicker from "../LanguagePicker.astro";
 
 interface Link {
   text?: string;
@@ -30,6 +31,7 @@ export interface Props {
   isDark?: boolean;
   isFullWidth?: boolean;
   showToggleTheme?: boolean;
+  showLangPicker?: boolean;
   showRssFeed?: boolean;
   position?: string;
 }
@@ -42,6 +44,7 @@ const {
   isDark = false,
   isFullWidth = false,
   showToggleTheme = false,
+  // showLangPicker = true,
   showRssFeed = false,
   position = "center",
 } = Astro.props;
@@ -129,6 +132,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`
       <div class="items-center flex justify-between w-full lg:w-auto">
         <div class="flex">
           {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 lg:w-5 lg:h-5 lg:inline-block" />}
+          <!-- {showLangPicker && <LanguagePicker />} -->
           {
             showRssFeed && (
               <a

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,17 +13,19 @@ import Analytics  from "~/components/common/Analytics.astro"
 import BasicScripts from '~/components/common/BasicScripts.astro';
 
 import type { MetaData as MetaDataType } from '~/types';
+import { getLangFromUrl } from '~/components/utils';
 
 export interface Props {
   metadata?: MetaDataType;
 }
 
+const lang = getLangFromUrl(Astro.url);
 const { metadata = {} } = Astro.props;
-const { language, textDirection } = I18N;
+const { textDirection } = I18N;
 ---
 
 <!DOCTYPE html>
-<html lang={language} dir={textDirection} class="2xl:text-[20px]">
+<html lang={lang} dir={textDirection} class="2xl:text-[20px]">
 
   <head>
     <CommonMeta />

--- a/src/pages/church.astro
+++ b/src/pages/church.astro
@@ -34,29 +34,42 @@ const metadata = {
     items={[
       {
         title: "Jesus is glorified ☀️",
-        description: "But he that glorieth, let him glory in the Lord. 2 Cor 10:17 KJV",
+        description: [
+          "But he that glorieth, let him glory in the Lord. 2 Cor 10:17 KJV",
+          "He shall glorify me: for he shall receive of mine, and shall shew it unto you. Joh 16:14 KJV",
+          "Whether therefore ye eat, or drink, or whatsoever ye do, do all to the glory of God. 1 Cor 10:31 KJV",
+        ],
         icon: "tabler:number-1",
       },
       {
         title: "The cross is preached ✝️",
-        description:
+        description: [
           "But we preach Christ crucified, unto the Jews a stumblingblock, and unto the Greeks foolishness. 1 Cor 1:23 KJV",
+          "Ye men of Israel, hear these words; Jesus of Nazareth, a man approved of God among you by miracles and wonders and signs, which God did by him in the midst of you, as ye yourselves also know: Him, being delivered by the determinate counsel and foreknowledge of God, ye have taken, and by wicked hands have crucified and slain: Whom God hath raised up, having loosed the pains of death: because it was not possible that he should be holden of it. Acts 2:22-24 KJV",
+          "Moreover, brethren, I declare unto you the gospel which I preached unto you, which also ye have received, and wherein ye stand; By which also ye are saved, if ye keep in memory what I preached unto you, unless ye have believed in vain. For I delivered unto you first of all that which I also received, how that Christ died for our sins according to the scriptures; And that he was buried, and that he rose again the third day according to the scriptures. 1 Cor 15:1-4 KJV",
+        ],
         icon: "tabler:number-2",
       },
       {
         title:
           "Love to God and to brethren abounds out of pure heart, and of good conscience and of faith unfeigned ❤️",
-        description:
+        description: [
           "Now the end of the commandment is charity out of a pure heart, and of a good conscience, and of faith unfeigned. 1 Tim 1:5 KJV",
+          "Whom having not seen, ye love; in whom, though now ye see him not, yet believing, ye rejoice with joy unspeakable and full of glory. 1 Pet 1:8 KJV",
+          "And this commandment have we from him, That he who loveth God love his brother also. 1 Joh 4:21 KJV",
+        ],
         icon: "tabler:number-3",
       },
       {
         title: "The love toward the world dies and love towards the things of the world dies 💔",
         description: [
+          "Ye adulterers and adulteresses, know ye not that the friendship of the world is enmity with God? whosoever therefore will be a friend of the world is the enemy of God. Jam 4:4 KJV",
           "Love not the world, neither the things that are in the world. If any man love the world, the love of the Father is not in him. For all that is in the world, the lust of the flesh, and the lust of the eyes, and the pride of life, is not of the Father, but is of the world. 1 Joh 2:15,16 KJV.",
           "Nothing in this world satisfies you anymore, you just want Jesus and more of Him.",
+          "These all died in faith, not having received the promises, but having seen them afar off, and were persuaded of them, and embraced them, and confessed that they were strangers and pilgrims on the earth. For they that say such things declare plainly that they seek a country. Heb 11:13,14 KJV",
           "That I may know him, and the power of his resurrection, and the fellowship of his sufferings, being made conformable unto his death. Phi 3:10 KJV.",
-          "If you have started to pray more, if you have started to read the Bible more, if you started to preach the gospel more, *then* you are in the right place.",
+          "If you have started to pray more, if you have started to read the Bible more, if you started to preach the gospel more, then you are in the right place.",
+          "But we will give ourselves continually to prayer, and to the ministry of the word. Acts 6:4 KJV",
           "Therefore, my beloved brethren, be ye stedfast, unmoveable, always abounding in the work of the Lord, forasmuch as ye know that your labour is not in vain in the Lord. 1 Cor 15:58 KJV.",
         ],
         icon: "tabler:number-4",
@@ -65,8 +78,10 @@ const metadata = {
         title:
           "Your passion to pray together and individually is kindled to full flame and just enlarges day by day. Wanting to pray hours and hours 🔥",
         description: [
-          "Now I beseech you, brethren, for the Lord Jesus Christ's sake, and for the love of the Spirit, that ye strive together with me in your prayers to God for me.Rom 15:30 KJV.",
-          "How alive a church is is noticed from its' prayer meeting directly. You want to know the state of the church, go to prayer meeting. If it is full of passion, fervency, heartfelt, Spirit and scripture filled prayers, then you are at the right place. If they pray for souls, agonize for dead churches, cry for the wayward, lay down in pain for the lost, travail for general revival, strive for the advancing of the gospel, and resist to blood against sin, *then* you are at the right place. If these are not found, the church has lost its first love and has a name but is dead. For out of the abundance of the heart the mouth speaketh.",
+          "And he spake a parable unto them to this end, that men ought always to pray, and not to faint. Luk 18:1 KJV",
+          "Now I beseech you, brethren, for the Lord Jesus Christ's sake, and for the love of the Spirit, that ye strive together with me in your prayers to God for me. Rom 15:30 KJV.",
+          "How alive a church is can be noticed from its' prayer meeting directly. You want to know the state of the church, go to the prayer meeting. If it is full of passion, fervency, heartfelt, Spirit and scripture filled prayers, then you are at the right place. If they pray for souls, agonize for dead churches, cry for the wayward, lay down in pain for the lost, travail for general revival, strive for the advancing of the gospel, and resist to blood against sin, *then* you are at the right place. If these are not found, the church has lost its first love and has a name but is dead. For out of the abundance of the heart the mouth speaketh.",
+          "And being let go, they went to their own company, and reported all that the chief priests and elders had said unto them. And when they heard that, they lifted up their voice to God with one accord... Acts 4:23,24a KJV",
           "O generation of vipers, how can ye, being evil, speak good things? for out of the abundance of the heart the mouth speaketh. Mat 12:34 KJV",
         ],
         icon: "tabler:number-5",
@@ -74,14 +89,16 @@ const metadata = {
       {
         title: "You get more people saved 👥👥👥",
         description: [
-          "And Jesus came and spake unto them, saying, All power is given unto me in heaven and in earth. Go ye therefore, and teach all nations, baptizing them in the name of the Father, and of the Son, and of the Holy Ghost: Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you always, even unto the end of the world. Amen. Mat 28:18-20 KJV.",
+          "The fruit of the righteous is a tree of life; and he that winneth souls is wise. Pro 11:30 KJV",
           "And he said unto them, Go ye into all the world, and preach the gospel to every creature. Mark 16:15 KJV",
+          "And Jesus came and spake unto them, saying, All power is given unto me in heaven and in earth. Go ye therefore, and teach all nations, baptizing them in the name of the Father, and of the Son, and of the Holy Ghost: Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you always, even unto the end of the world. Amen. Mat 28:18-20 KJV.",
         ],
         icon: "tabler:number-6",
       },
       {
         title: "Holiness is preached and is evident in the life of people 🛁🧼",
         description: [
+          "Ye are witnesses, and God also, how holily and justly and unblameably we behaved ourselves among you that believe. 1 The 2:10 KJV",
           "But as he which hath called you is holy, so be ye holy in all manner of conversation; Because it is written, Be ye holy; for I am holy. And if ye call on the Father, who without respect of persons judgeth according to every man's work, pass the time of your sojourning here in fear: Forasmuch as ye know that ye were not redeemed with corruptible things, as silver and gold, from your vain conversation received by tradition from your fathers; But with the precious blood of Christ, as of a lamb without blemish and without spot. 1 Pet 1:15-20 KJV.",
           "Beloved, now are we the sons of God, and it doth not yet appear what we shall be: but we know that, when he shall appear, we shall be like him; for we shall see him as he is. And every man that hath this hope in him purifieth himself, even as he is pure. 1 Joh 3:2,3 KJV.",
         ],
@@ -89,13 +106,16 @@ const metadata = {
       },
       {
         title: "Sin is hated and judged ❌",
-        description:
+        description: [
+          "And found in the temple those that sold oxen and sheep and doves, and the changers of money sitting: And when he had made a scourge of small cords, he drove them all out of the temple, and the sheep, and the oxen; and poured out the changers' money, and overthrew the tables; And said unto them that sold doves, Take these things hence; make not my Father's house an house of merchandise. Joh 2:14-16 KJV",
+          "And others save with fear, pulling them out of the fire; hating even the garment spotted by the flesh. Jud 1:23 KJV",
           "For I verily, as absent in body, but present in spirit, have judged already, as though I were present, concerning him that hath so done this deed, In the name of our Lord Jesus Christ, when ye are gathered together, and my spirit, with the power of our Lord Jesus Christ, To deliver such an one unto Satan for the destruction of the flesh, that the spirit may be saved in the day of the Lord Jesus. Your glorying is not good. Know ye not that a little leaven leaveneth the whole lump? 1 Cor 5:3-6 KJV.",
+        ],
         icon: "tabler:number-8",
       },
       {
         title:
-          "Sin ceases from your life, you are released from your oppressions, the addictions are broken, sicknesses are healed, demons are being cast out, LIVES are being transformed by The Power of GOD! 💥",
+          "Sin ceases from your life, you are released from your oppressions, the addictions are broken, sicknesses are healed, demons are being cast out, LIVES are being transformed by the POWER of GOD! 💥",
         description: [
           "And these signs shall follow them that believe; In my name shall they cast out devils; they shall speak with new tongues; They shall take up serpents; and if they drink any deadly thing, it shall not hurt them; they shall lay hands on the sick, and they shall recover. Mark 16:17,18 KJV.",
           "The Spirit of the Lord is upon me, because he hath anointed me to preach the gospel to the poor; he hath sent me to heal the brokenhearted, to preach deliverance to the captives, and recovering of sight to the blind, to set at liberty them that are bruised. Luke 4:18 KJV.",
@@ -105,7 +125,7 @@ const metadata = {
         icon: "tabler:number-9",
       },
       {
-        title: "There is liberty, righteousness, joy and peace in the Holy Ghost 🗽",
+        title: "There is liberty, righteousness, joy and peace in the Holy Ghost ✅",
         description: [
           "For the kingdom of God is not meat and drink; but righteousness, and peace, and joy in the Holy Ghost. Rom 14:17 KJV.",
           "Now the Lord is that Spirit: and where the Spirit of the Lord is, there is liberty. 2 Cor 3:17 KJV.",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes made to several files, such as LanguagePicker.astro, ui.ts, and utils.ts. It introduces a new file, LanguagePicker.astro, that displays a list of languages with corresponding links. It also defines the 'languages' object in ui.ts with English and Finnish options, and the 'ui' object with translations for different languages. The 'showDefaultLang' variable is set to false. No changes are made to utils.ts.
> 
> ## What changed
> - Created a new file, LanguagePicker.astro, that displays a list of languages with corresponding links.
> - Defined the 'languages' object in ui.ts with English and Finnish options.
> - Defined the 'ui' object in ui.ts with translations for different languages.
> - Set the 'showDefaultLang' variable to false.
> 
> ## How to test
> 1. Open the LanguagePicker.astro file and verify that it displays a list of languages with corresponding links.
> 2. Open the ui.ts file and check that the 'languages' object is defined with English and Finnish options.
> 3. Verify that the 'ui' object in ui.ts contains translations for different languages.
> 4. Check that the 'showDefaultLang' variable is set to false.
> 
> ## Why make this change
> This change was made to add a LanguagePicker component that displays a list of languages with corresponding links. It also defines translations for different languages in the 'ui' object and sets the 'showDefaultLang' variable to false. These changes improve the user experience by providing language options and translations for different languages.
</details>