### PR TITLE
fix: about content height, README up

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ Made by Juhani Juusola out of love for God • All rights reserved.
 
 ## Acknowledgements
 
-Initially created by [onWidget](https://onwidget.com) [AstroWind](https://github.com/onwidget/astrowind) and maintained by a community of [contributors](https://github.com/onwidget/astrowind/graphs/contributors).
+Initially created by [onWidget](https://onwidget.com) ([AstroWind])(https://github.com/onwidget/astrowind) and maintained by a community of [contributors](https://github.com/onwidget/astrowind/graphs/contributors).

--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -6,7 +6,6 @@ const lang = getLangFromUrl(Astro.url);
 
 const changeLangInUrl = () => {
   let url = Astro.url.toString();
-  console.log(url)
   if (url.includes("/en/")) {
     url = url.replace("/en/", "/fi/");
   } else if (url.includes("/en")) {

--- a/src/components/common/ToggleTheme.astro
+++ b/src/components/common/ToggleTheme.astro
@@ -1,7 +1,7 @@
 ---
-import { Icon } from 'astro-icon/components';
+import { Icon } from "astro-icon/components";
 
-import { UI } from '~/utils/config';
+import { UI } from "~/utils/config";
 
 export interface Props {
   label?: string;
@@ -11,22 +11,23 @@ export interface Props {
 }
 
 const {
-  label = 'Toggle between Dark and Light mode',
+  label = "Toggle between Dark and Light mode",
   class:
-    className = 'text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center',
-  iconClass = 'w-6 h-6',
-  iconName = 'tabler:sun',
+    className = "text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center",
+  iconClass = "w-6 h-6",
+  iconName = 'tabler:sun'
 } = Astro.props;
+
 ---
 
 {
-  !(UI.theme && UI.theme.endsWith(':only')) && (
+  !(UI.theme && UI.theme.endsWith(":only")) && (
     <button type="button" class={className} aria-label={label} data-aw-toggle-color-scheme>
       <Icon name={iconName} class={iconClass} />
     </button>
   )
 }
-  <!-- const changeThemeIcon = (theme: "system" | "light" | "dark" | "light:only" | "dark:only") => {
+<!-- const changeThemeIcon = (theme: "system" | "light" | "dark" | "light:only" | "dark:only") => {
     console.log(theme);
     if (theme.endsWith(":only")) {
       return;

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -22,6 +22,6 @@ const { tagline = "about.hero.tagline" } = Astro.props;
 
   <div class="flex-col w-full">
     <HeroText tagline={t(tagline as any)} title={t("about.heto.title")} />
-    <div class="w-full h-[calc(100vh-400px)]"></div>
+    <div class="w-full h-[calc(100vh-375px)] lg:h-[calc(100vh-400px)] 2xl:h-[calc(100vh-500px)]"></div>
   </div>
 </Layout>


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request includes changes to the README file, removal of a console log statement, changes to string quotes, and an adjustment to a div height calculation.
> 
> ## What changed
> - In the README file, parentheses were added around the AstroWind link for better readability.
> - In the LanguagePicker.astro file, a console log statement was removed to clean up the code.
> - In the ToggleTheme.astro file, single quotes were replaced with double quotes for string consistency.
> - In the about.astro file, the height calculation for a div was adjusted to be responsive at different viewport sizes.
> 
> ## How to test
> To test these changes, follow these steps:
> 1. Pull down this branch locally.
> 2. Check the README file to ensure the AstroWind link is correctly formatted.
> 3. Navigate to the LanguagePicker component and ensure there are no console log statements.
> 4. In the ToggleTheme component, ensure all strings are enclosed in double quotes.
> 5. Navigate to the about page and resize the viewport to ensure the div height adjusts correctly.
> 
> ## Why make this change
> These changes improve the readability and consistency of the code, remove unnecessary log statements, and improve the responsiveness of the about page.
</details>