### PR TITLE
fix: index 2nd video scaling on small devices

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -251,16 +251,16 @@ const t = useTranslations(lang);
 
   <Content>
     <Fragment slot="content">
-      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+      <h3 class="text-2xl tracking-tight sm:text-xl mb-2">
         {t("index.content4.subtitle")}
       </h3>
-      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+      <h3 class="text-2xl tracking-tight sm:text-xl mb-2">
         {t("index.content4.subtitle2")}
       </h3>
     </Fragment>
 
     <Fragment slot="image">
-      <div class="relative">
+      <div class="relative pb-[56.25%]">
         <iframe
           loading="lazy"
           width="560"
@@ -268,6 +268,7 @@ const t = useTranslations(lang);
           src="https://www.youtube.com/embed/g_y65xR5OYE?si=JwRc2jad8g1Swu3h"
           title="YouTube video player"
           frameborder="0"
+          class="absolute top-0 left-0 w-full h-full"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           referrerpolicy="strict-origin-when-cross-origin"
           allowfullscreen></iframe>


### PR DESCRIPTION
### TL;DR

Improved responsive design and layout for the content and embedded YouTube video on the English index page.

### What changed?

- Fixed a typo in the `tracking-tight` class for two `h3` elements.
- Added a responsive padding-bottom to the video container div.
- Applied positioning classes to the iframe to make it responsive and fill its container.

### How to test?

1. Navigate to the English index page.
2. Verify that the text styling for the two subtitles is consistent and properly spaced.
3. Check the embedded YouTube video's responsiveness by resizing the browser window.
4. Ensure the video maintains a 16:9 aspect ratio and fills its container at various screen sizes.

### Why make this change?

These changes improve the overall user experience by:
1. Ensuring consistent text styling across different screen sizes.
2. Making the embedded YouTube video fully responsive, which prevents layout issues on mobile devices and maintains proper aspect ratio across all screen sizes.