### PR TITLE
feat: Jesus Fest winter revival

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -207,10 +207,16 @@ export const ui = {
     "events.hero.subtitle2": "with signs following. Amen.' Mark 16:20 KJV",
     "events.hero.subtitle.span": " the word ",
     "events.hero.callToAction": "Explore our meetings",
+    "events.heroEvent.tagline": "Coming events",
+    "events.heroEvent.title1": "Jesus Fest winter revival",
+    "events.heroEvent.subtitle1":
+      "December 18 – 22, 2024; 11:00 – 14:00​ Kulttuuriareena 44, 70110 Kuopio​",
     "events.hero2.tagline": "Past events",
     "events.hero2.title1": "JESUS FEST KUOPIO",
     "events.hero2.subtitle1":
       "June 7 – 9, 2024; 17:00 – 20:00​ Kauppatori, 70100 Kuopio​",
+    "events.hero2.subtitle2": "+100 visitors",
+    "events.hero2.subtitle3": "Miracles: Jesus delivered 40 years old person from demonic dreams that had lasted a long time.",
     "events.features2.title": "Our songs for the event",
     "events.features2.subtitle": "Wells of salvation",
     "events.features2.items1.title": "En",
@@ -1250,10 +1256,16 @@ export const ui = {
     "events.hero.subtitle2": "sitä seuraavien merkkien kautta.' Amen. Mar 16:20 FINRK",
     "events.hero.subtitle.span": " sanan ",
     "events.hero.callToAction": "Tutustu tapaamisiimme",
+    "events.heroEvent.tagline": "Tulevat tapahtumat",
+    "events.heroEvent.title1": "Jesus Fest talvi herätys",
+    "events.heroEvent.subtitle1":
+      "Jou 18 – 22, 2024; 11:00 – 14:00​ Kulttuuriareena 44, 70110 Kuopio​",
     "events.hero2.tagline": "Menneet tapahtumat",
     "events.hero2.title1": "JESUS FEST KUOPIO",
     "events.hero2.subtitle1":
       "Kesäkuu 7 – 9, 2024; 17:00 – 20:00​ Kauppatori, 70100 Kuopio​",
+    "events.hero2.subtitle2": "+100 kävijää",
+    "events.hero2.subtitle3": "Ihmeitä: Jeesus vapautti 40 vuotiaan henkilön pitkään jatkuneista demonisista unista.",
     "events.features2.title": "Laulumme tapahtumaa varten",
     "events.features2.subtitle": "Pelastuksen lähteet",
     "events.features3.subtitle": "Jeesus Kristus Jumalan Poika",

--- a/src/pages/en/events.astro
+++ b/src/pages/en/events.astro
@@ -1,5 +1,6 @@
 ---
 import CallToAction from "~/components/widgets/CallToAction.astro";
+import Content from "~/components/widgets/Content.astro";
 import Features2 from "~/components/widgets/Features2.astro";
 import Hero from "~/components/widgets/Hero.astro";
 import Image from "~/components/common/Image.astro";
@@ -32,6 +33,82 @@ const t = useTranslations(lang);
       <GradientText class="font-bold" text={t("events.hero.subtitle.span")} />{t("events.hero.subtitle2")}
     </Fragment>
   </Hero>
+
+  <!-- Hero Widget *******************-->
+
+  <Hero
+  tagline={t("events.heroEvent.tagline")}
+    image={{
+      src:
+        lang === "en"
+          ? "https://lh3.googleusercontent.com/d/128L4LWy_G4SkUo124TFex5M5lHhcZ-Bl"
+          : "https://lh3.googleusercontent.com/d/1oYImiMjiA2yo3AvoYsCvi9JTQw7pllBY",
+      alt: "Jesus fest kuopio",
+    }}
+  >
+    <Fragment slot="title">
+      <!-- <pre>{`┬\n⏐\n⏐\n⏐\n⏐\n˅`}</pre> -->
+      {t("events.heroEvent.title1")}
+    </Fragment>
+    <Fragment slot="subtitle">
+      {t("events.heroEvent.subtitle1")}
+    </Fragment>
+  </Hero>
+
+  <!-- Anchor to leave the scroll to leave Features2 title visible **************-->
+
+  <div id="songs"></div>
+
+  <!-- Features2 Widget **************-->
+  <Features2
+    hrefID="songs"
+    class="container"
+    title={t("events.features2.title")}
+    subtitle={t("events.features2.subtitle")}
+    columns={2}
+    items={[
+      {
+        title: t("events.features2.items1.title"),
+        description: t("events.features2.items1.description"),
+        // icon: "tabler:book",
+      },
+      // {
+      //   title: t("events.features2.items2.title"),
+      //   description: t("events.features2.items2.description"),
+      //   // icon: "tabler:pray",
+      // },
+      {
+        title: t("events.features2.items3.title"),
+        description: t("events.features2.items3.description"),
+        // icon: "tabler:friends",
+      },
+    ]}
+  />
+
+  <!-- Features2 Widget **************-->
+
+  <Features2
+    subtitle={t("events.features3.subtitle")}
+    columns={2}
+    items={[
+      {
+        title: t("events.features3.items1.title"),
+        description: t("events.features3.items1.description"),
+        // icon: "tabler:book",
+      },
+      {
+        title: t("events.features3.items2.title"),
+        description: t("events.features3.items2.description"),
+        // icon: "tabler:pray",
+      },
+    ]}
+  />
+
+  <!-- Text section -->
+
+  <div class="w-full flex flex-col items-center px-10">
+    <div class="my-40 h-[1px] bg-neutral-400 w-full"></div>
+  </div>
 
   <!-- Note Widget ******************* -->
 
@@ -104,6 +181,40 @@ const t = useTranslations(lang);
     ]}
   />
 
+  <!-- tagline={t("events.hero2.tagline")} -->
+  <Content tagline={t("events.hero2.tagline")} isReversed>
+    <Fragment slot="content">
+      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+        {t("events.hero2.title1")}
+      </h3>
+      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+        {t("events.hero2.subtitle1")}
+      </h3>
+      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+        {t("events.hero2.subtitle2")}
+      </h3>
+      <h3 class="text-2xl tracking-tightsm:text-xl mb-2">
+        {t("events.hero2.subtitle3")}
+      </h3>
+    </Fragment>
+
+    <Fragment slot="image">
+      <div class="relative pb-[56.25%]">
+        <iframe
+          loading="lazy"
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/g_y65xR5OYE?si=JwRc2jad8g1Swu3h"
+          title="YouTube video player"
+          frameborder="0"
+          class="absolute top-0 left-0 w-full h-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allowfullscreen></iframe>
+      </div>
+    </Fragment>
+  </Content>
+
   <!-- Text section -->
 
   <div class="w-full flex flex-col items-center px-10">
@@ -164,84 +275,6 @@ const t = useTranslations(lang);
       {t("events.callToAction.subtitle3")}
     </Fragment>
   </CallToAction>
-
-
-  <!-- Text section -->
-
-  <div class="w-full flex flex-col items-center px-10">
-    <div class="my-40 h-[1px] bg-neutral-400 w-full"></div>
-  </div> 
-
-  <!-- Hero Widget *******************-->
-
-  <Hero
-    tagline={t("events.hero2.tagline")}
-    image={{
-      src:
-        lang === "en"
-          ? "https://lh3.googleusercontent.com/d/14Bl0MQwg-O19jq3vI9O8LifTfDAqHgzk"
-          : "https://lh3.googleusercontent.com/d/1Mj2eLlPLuF-5BkeEKQyZyWpQJqz-hauo",
-      alt: "Jesus fest kuopio",
-    }}
-  >
-    <Fragment slot="title">
-      <pre>{`┬\n⏐\n⏐\n⏐\n⏐\n˅`}</pre>
-      {t("events.hero2.title1")}
-    </Fragment>
-    <Fragment slot="subtitle">
-      {t("events.hero2.subtitle1")}
-    </Fragment>
-  </Hero>
-
-  <!-- Anchor to leave the scroll to leave Features2 title visible **************-->
-
-  <div id="songs"></div>
-
-  <!-- Features2 Widget **************-->
-  <Features2
-    hrefID="songs"
-    class="container"
-    title={t("events.features2.title")}
-    subtitle={t("events.features2.subtitle")}
-    columns={2}
-    items={[
-      {
-        title: t("events.features2.items1.title"),
-        description: t("events.features2.items1.description"),
-        // icon: "tabler:book",
-      },
-      // {
-      //   title: t("events.features2.items2.title"),
-      //   description: t("events.features2.items2.description"),
-      //   // icon: "tabler:pray",
-      // },
-      {
-        title: t("events.features2.items3.title"),
-        description: t("events.features2.items3.description"),
-        // icon: "tabler:friends",
-      },
-    ]}
-  />
-
-  <!-- Features2 Widget **************-->
-
-  <Features2
-    subtitle={t("events.features3.subtitle")}
-    columns={2}
-    items={[
-      {
-        title: t("events.features3.items1.title"),
-        description: t("events.features3.items1.description"),
-        // icon: "tabler:book",
-      },
-      {
-        title: t("events.features3.items2.title"),
-        description: t("events.features3.items2.description"),
-        // icon: "tabler:pray",
-      },
-    ]}
-  />
-
 </Layout>
 
 <style lang="css">


### PR DESCRIPTION
### TL;DR

Added information about upcoming and past events on the Events page.

### What changed?

- Added a new "Coming events" section with details about the Jesus Fest winter revival.
- Updated the "Past events" section with additional information about the JESUS FEST KUOPIO event, including visitor count and a notable miracle.
- Reorganized the layout of the Events page, moving the past events section higher up.
- Included a YouTube video embed for the past event.
- Added new translations for the added content in both English and Finnish.

### How to test?

1. Navigate to the Events page in both English and Finnish versions.
2. Verify that the new "Coming events" section is visible with correct information.
3. Check that the "Past events" section now includes visitor count and miracle information.
4. Ensure the YouTube video for the past event loads and plays correctly.
5. Confirm that all new content is properly translated in both languages.

### Why make this change?

This update provides more comprehensive information about both upcoming and past events, giving visitors a better understanding of the organization's activities. The addition of specific details like visitor counts and notable occurrences helps to showcase the impact and significance of these events. The reorganization of the page improves the user experience by presenting the most relevant information more prominently.