### PR TITLE
fix: hide lang picker

### DIFF
--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -135,7 +135,7 @@ const t = useTranslations(lang);
     >
       <div class="items-center flex justify-between w-full xl:w-auto">
         <div class="flex">
-          {showLangPicker && <LanguagePicker />}
+          <!-- {showLangPicker && <LanguagePicker />} -->
           {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 xl:w-5 xl:h-5 xl:inline-block" />}
           {
             showRssFeed && (


### PR DESCRIPTION
### TL;DR

Commented out the LanguagePicker component in the Header.

### What changed?

The LanguagePicker component within the Header has been commented out. This change affects the display of language selection options in the header of the website.

### How to test?

1. Navigate to the website's header section.
2. Verify that the language picker is no longer visible.
3. Ensure that other header elements, such as the theme toggle and RSS feed (if applicable), are still present and functioning correctly.

### Why make this change?

This change was likely made to temporarily disable or remove the language selection feature from the header. Possible reasons could include:

1. Simplifying the user interface.
2. Preparing for a different language selection implementation.
3. Removing a feature that is no longer needed or supported.
4. Troubleshooting issues related to the language picker.

Further context from the development team would be helpful to understand the specific motivation behind this change.