### PR TITLE
fix: church, LanguagePicker

### DIFF
--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -6,24 +6,29 @@ import { getPermalink } from "~/utils/permalinks";
 
 const lang = getLangFromUrl(Astro.url);
 
-const changeLangInUrl = (lng: "en" | "fi") => {
+const changeLangInUrl = (permaLink: string, lng?: "en" | "fi") => {
   const str = Astro.url.pathname;
+
+  // If path is the root ('/')
+  if (str === "/" || str === "") {
+    if (lng === "en" || !lng) return ""; // Ensure /en/ or /fi/ for base form
+    return `${Astro.url.origin}/${lng}`; // Ensure /en/ or /fi/ for base form
+  }
 
   // Remove everything before 'en' or 'fi'
   const cleanStr = str.replace(/^.*?(en|fi)/, (match, p1) => p1);
 
+  let t = "";
   // Swap 'en' with 'fi' or 'fi' with 'en'
   if (cleanStr.startsWith("en")) {
-    if (lng === "en") return cleanStr;
-    return cleanStr.replace("en", "fi");
+    if (lng === "en") t = `${permaLink}${cleanStr}`;
+    else t = `${permaLink}${cleanStr.replace("en", "fi")}`;
   } else if (cleanStr.startsWith("fi")) {
-    console.log("jere");
-    if (lng === "fi") return cleanStr;
-    return cleanStr.replace("fi", "en");
+    if (lng === "fi") t = `${permaLink}${cleanStr}`;
+    else t = `${permaLink}${cleanStr.replace("fi", "")}`;
   }
 
-  // If 'en' or 'fi' is not found, return the original string
-  return `/${lng}${str}`;
+  return t.replace("enfi", "en");
 };
 ---
 
@@ -40,6 +45,7 @@ const changeLangInUrl = (lng: "en" | "fi") => {
                 lng === "en" && "bg-gray-300 dark:bg-gray-700 "
               )}
               href={`${getPermalink()}${changeLangInUrl("en")}`}
+              href={`${changeLangInUrl(getPermalink(), "en")}`}
             >
               {/* {label} */}
               <img
@@ -53,7 +59,7 @@ const changeLangInUrl = (lng: "en" | "fi") => {
                 "gap-2 text-muted text-lg justify-center items-center font-semibold lg:text-base w-11 h-11 lg:w-10 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-300 dark:focus:ring-gray-700 rounded-lg p-2.5 inline-flex",
                 lng === "fi" && "bg-gray-300 dark:bg-gray-700 "
               )}
-              href={`${getPermalink()}${changeLangInUrl("fi")}`}
+              href={`${changeLangInUrl(getPermalink(), "fi")}`}
             >
               {/* {label} */}
               <img

--- a/src/components/ui/Test.astro
+++ b/src/components/ui/Test.astro
@@ -1,0 +1,48 @@
+---
+import { twMerge } from "tailwind-merge";
+
+export interface Props {
+  //   items?: Array<Item>;
+  //   defaultIcon?: string;
+  classes?: Record<string, string>;
+  description:
+    | string
+    | {
+        text: string;
+        link?: boolean;
+        subtitle?: boolean;
+      }[]
+    | undefined;
+}
+
+const { classes = {}, description } = Astro.props as Props;
+
+const { description: descriptionClass = "" } = classes;
+---
+
+{
+  description && Array.isArray(description)
+    ? description.map((item) =>
+        item.link ? (
+          <a
+            class={twMerge("text-blue-700 mt-2 hover:underline break-all", descriptionClass, classes?.description)}
+            set:html={item.text}
+            href={item.text.toString()}
+            target="_blank"
+          />
+        ) : (
+          <p
+            class={twMerge(
+              "text-muted mt-2",
+              descriptionClass,
+              classes?.description,
+              item.subtitle && "text-dark dark:text-white font-semibold"
+            )}
+            set:html={item.text}
+          />
+        )
+      )
+    : description && (
+        <p class={twMerge("text-muted mt-2", descriptionClass, classes?.description)} set:html={description} />
+      )
+}

--- a/src/components/ui/Timeline.astro
+++ b/src/components/ui/Timeline.astro
@@ -2,6 +2,7 @@
 import { Icon } from "astro-icon/components";
 import { twMerge } from "tailwind-merge";
 import type { Item } from "~/types";
+import Test from "./Test.astro";
 
 export interface Props {
   items?: Array<Item>;
@@ -46,37 +47,7 @@ const {
           </div>
           <div class={`pt-1 ${index !== items.length - 1 ? "pb-8" : ""}`}>
             {title && <p class={twMerge("text-xl font-bold", titleClass, itemClasses?.title)} set:html={title} />}
-            {description && Array.isArray(description)
-              ? description.map((item) =>
-                  item.link ? (
-                    <a
-                      class={twMerge(
-                        "text-blue-700 mt-2 hover:underline break-all",
-                        descriptionClass,
-                        itemClasses?.description
-                      )}
-                      set:html={item.text}
-                      href={item.text.toString()}
-                      target="_blank"
-                    />
-                  ) : (
-                    <p
-                      class={twMerge(
-                        "text-muted mt-2",
-                        descriptionClass,
-                        itemClasses?.description,
-                        item.subtitle && "text-dark dark:text-white font-semibold"
-                      )}
-                      set:html={item.text}
-                    />
-                  )
-                )
-              : description && (
-                  <p
-                    class={twMerge("text-muted mt-2", descriptionClass, itemClasses?.description)}
-                    set:html={description}
-                  />
-                )}
+            <Test description={description} />
           </div>
         </div>
       ))}

--- a/src/pages/en/church.astro
+++ b/src/pages/en/church.astro
@@ -118,6 +118,12 @@ const t = useTranslations(lang);
         ],
         icon: "tabler:number-8",
       },
+    ]}
+  />
+
+  <Steps
+    isReversed={true}
+    items={[
       {
         title: t("church.steps.items9.title"),
         description: [


### PR DESCRIPTION
### TL;DR

Improved language picker functionality and refactored timeline component.

### What changed?

- Enhanced `LanguagePicker.astro` to handle root path and improve URL manipulation for language switching.
- Created a new `Test.astro` component to handle description rendering.
- Refactored `Timeline.astro` to use the new `Test.astro` component for description rendering.
- Updated `church.astro` to split the steps into two separate `Steps` components.

### How to test?

1. Test language switching on various pages, including the root path.
2. Verify that the timeline component renders descriptions correctly, including links and subtitles.
3. Check the church page to ensure the steps are displayed correctly in two separate sections.

### Why make this change?

- To improve the language switching functionality, especially for the root path.
- To reduce code duplication and improve maintainability by extracting description rendering logic into a separate component.
- To enhance the layout of the church page by splitting the steps into two sections.