### PR TITLE
fix: temp fix for home > fi

### DIFF
--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -12,7 +12,7 @@ const changeLangInUrl = (permaLink: string, lng?: "en" | "fi") => {
   // If path is the root ('/')
   if (str === "/" || str === "") {
     if (lng === "en" || !lng) return ""; // Ensure /en/ or /fi/ for base form
-    return `${Astro.url.origin}/${lng}`; // Ensure /en/ or /fi/ for base form
+    return "https://flamethefreeze.com/fi/"; // Ensure /en/ or /fi/ for base form
   }
 
   // Remove everything before 'en' or 'fi'


### PR DESCRIPTION
### TL;DR

Updated the URL generation for the Finnish language option in the LanguagePicker component.

### What changed?

Modified the `changeLangInUrl` function to return a hardcoded URL for the Finnish language option when the path is root ('/') or empty. The new URL is set to "https://flamethefreeze.com/fi/".

### How to test?

1. Navigate to the root page of the website.
2. Open the language picker component.
3. Select the Finnish language option.
4. Verify that the URL changes to "https://flamethefreeze.com/fi/".

### Why make this change?

This change ensures a consistent and specific URL for the Finnish language version of the website's homepage. It replaces the dynamic URL generation with a hardcoded value, potentially improving reliability and reducing the risk of incorrect URL formation.