### PR TITLE
fix(about): return heart but as a component

### DIFF
--- a/src/components/widgets/Heart.astro
+++ b/src/components/widgets/Heart.astro
@@ -1,0 +1,87 @@
+---
+import WidgetWrapper from "~/components/ui/WidgetWrapper.astro";
+import Headline from "~/components/ui/Headline.astro";
+import type { Features } from "~/types";
+import GradientText from "~/components/ui/GradientText.astro";
+import { getLangFromUrl, useTranslations } from "~/i18n/utils";
+
+const {
+  title = await Astro.slots.render("title"),
+  subtitle = await Astro.slots.render("subtitle"),
+  tagline = await Astro.slots.render("tagline"),
+
+  id,
+  isDark = false,
+  classes = {},
+  bg = await Astro.slots.render("bg"),
+} = Astro.props as Features;
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+---
+
+<WidgetWrapper id={id} isDark={isDark} containerClass={`max-w-5xl ${classes?.container ?? ""}`} bg={bg}>
+  <Headline title={title} subtitle={subtitle} tagline={tagline} classes={classes?.headline} />
+  <div class="w-full flex flex-col items-center pt-16 px-10">
+    <div class="heart"></div>
+    <div class="h-20"></div>
+    <GradientText class="font-bold text-6xl sm:text-8xl md:text-9xl flex" text={t("about.h2")} />
+    <div class="my-40 h-[1px] bg-neutral-400 w-full"></div>
+  </div>
+</WidgetWrapper>
+
+<style>
+  .heart {
+    width: 80px;
+    height: 80px;
+    background-color: red;
+    position: relative;
+    transform: rotate(45deg);
+    box-shadow:
+      0 2.8px 2.2px rgba(0, 0, 0, 0.034),
+      0 6.7px 5.3px rgba(0, 0, 0, 0.048),
+      0 12.5px 10px rgba(0, 0, 0, 0.06),
+      0 22.3px 17.9px rgba(0, 0, 0, 0.072);
+    animation: hbeat 1s linear infinite;
+  }
+
+  .heart::before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    position: absolute;
+    border-radius: 50%;
+    transform: translateY(-50%);
+  }
+  .heart::after {
+    content: "";
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    position: absolute;
+    border-radius: 50%;
+    transform: translateX(-50%);
+  }
+
+  @keyframes hbeat {
+    0% {
+      transform: rotate(45deg) scale(1);
+    }
+    20% {
+      transform: rotate(45deg) scale(1);
+    }
+    40% {
+      transform: rotate(45deg) scale(1.4);
+    }
+    60% {
+      transform: rotate(45deg) scale(1.2);
+    }
+    80% {
+      transform: rotate(45deg) scale(1.4);
+    }
+    100% {
+      transform: rotate(45deg) scale(1);
+    }
+  }
+</style>

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -4,6 +4,7 @@ import Content from "~/components/widgets/Content.astro";
 import Hero from "~/components/widgets/Hero.astro";
 import Steps from "~/components/widgets/Steps.astro";
 import Features from "~/components/widgets/Features.astro";
+import Heart from "~/components/widgets/Heart.astro";
 import Testimonials from "~/components/widgets/Testimonials.astro";
 import GradientText from "~/components/ui/GradientText.astro";
 import { getLangFromUrl, useTranslations } from "~/i18n/utils";
@@ -117,24 +118,14 @@ const t = useTranslations(lang);
     ]}
   />
 
-  <!-- Features Widget *************** -->
-
-  <Features>
+  <!-- Heart section -->
+  <Heart>
     <Fragment slot="title">
       {t("about.features2.title1")}
       <GradientText class="font-bold" text={t("about.features2.title.span")} />{t("about.features2.title2")}
       <GradientText class="font-bold" text={t("about.features2.title.span")} />{t("about.features2.title3")}
     </Fragment>
-  </Features>
-
-  <!-- Text section -->
-
-  <div class="w-full flex flex-col items-center px-10">
-    <div class="heart md:flex hidden"></div>
-    <div class="h-20"></div>
-    <GradientText class="font-bold text-6xl sm:text-8xl md:text-9xl flex" text={t("about.h2")} />
-    <div class="my-40 h-[1px] bg-neutral-400 w-full"></div>
-  </div>
+  </Heart>
 
   <!-- Content Widget **************** -->
 
@@ -223,58 +214,3 @@ const t = useTranslations(lang);
     </div>
   </section> -->
 </Layout>
-<style>
-  .heart {
-    width: 80px;
-    height: 80px;
-    background-color: red;
-    position: relative;
-    transform: rotate(45deg);
-    box-shadow:
-      0 2.8px 2.2px rgba(0, 0, 0, 0.034),
-      0 6.7px 5.3px rgba(0, 0, 0, 0.048),
-      0 12.5px 10px rgba(0, 0, 0, 0.06),
-      0 22.3px 17.9px rgba(0, 0, 0, 0.072);
-    animation: hbeat 1s linear infinite;
-  }
-
-  .heart::before {
-    content: "";
-    width: 100%;
-    height: 100%;
-    background-color: red;
-    position: absolute;
-    border-radius: 50%;
-    transform: translateY(-50%);
-  }
-  .heart::after {
-    content: "";
-    width: 100%;
-    height: 100%;
-    background-color: red;
-    position: absolute;
-    border-radius: 50%;
-    transform: translateX(-50%);
-  }
-
-  @keyframes hbeat {
-    0% {
-      transform: rotate(45deg) scale(1);
-    }
-    20% {
-      transform: rotate(45deg) scale(1);
-    }
-    40% {
-      transform: rotate(45deg) scale(1.4);
-    }
-    60% {
-      transform: rotate(45deg) scale(1.2);
-    }
-    80% {
-      transform: rotate(45deg) scale(1.4);
-    }
-    100% {
-      transform: rotate(45deg) scale(1);
-    }
-  }
-</style>


### PR DESCRIPTION
### TL;DR

Created a new Heart component and integrated it into the about page.

### What changed?

- Added a new `Heart.astro` component in the `src/components/widgets` directory.
- The Heart component includes a pulsating heart animation and a gradient text.
- Updated `src/pages/en/about.astro` to use the new Heart component.
- Removed inline styles from the about page and moved them to the Heart component.

### How to test?

1. Navigate to the about page.
2. Verify that the heart animation is visible and functioning correctly.
3. Check that the gradient text below the heart is displayed properly.
4. Ensure that the layout and styling of the about page remain consistent with the previous version.

### Why make this change?

This change improves code organization by extracting the heart animation and related content into a separate, reusable component. It enhances maintainability and makes it easier to use this feature across different pages if needed in the future.