### PR TITLE
fix: animations broken in fivefold and witnesses

### DIFF
--- a/src/components/ui/WidgetWrapper.astro
+++ b/src/components/ui/WidgetWrapper.astro
@@ -2,7 +2,7 @@
 import { twMerge } from "tailwind-merge";
 import Background from "./Background.astro";
 
-const { id, isDark = false, containerClass = "", bg, as = "section" } = Astro.props;
+const { id, isDark = false, containerClass = "", bg, noAnimation, as = "section" } = Astro.props;
 
 const WrapperTag = as;
 ---
@@ -16,7 +16,10 @@ const WrapperTag = as;
   <div
     class:list={[
       twMerge(
-        "relative mx-auto max-w-7xl px-4 md:px-6 py-12 md:py-16 lg:py-20 text-default intersect-once intersect-quarter intercept-no-queue motion-safe:opacity-0 motion-safe:intersect:animate-fade",
+        "relative mx-auto max-w-7xl px-4 md:px-6 py-12 md:py-16 lg:py-20 text-default",
+        noAnimation
+          ? "no-intersect"
+          : "intersect-once intersect-quarter intercept-no-queue motion-safe:opacity-0 motion-safe:intersect:animate-fade",
         containerClass
       ),
       { dark: isDark },

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -28,6 +28,7 @@ const {
   isDark = false,
   classes = {},
   bg = await Astro.slots.render("bg"),
+  noAnimation = false,
 } = Astro.props as Content;
 ---
 
@@ -36,6 +37,7 @@ const {
   isDark={isDark}
   containerClass={`max-w-7xl mx-auto ${isAfterContent ? "pt-0 md:pt-0 lg:pt-0" : ""} ${classes?.container ?? ""}`}
   bg={bg}
+  noAnimation={noAnimation}
 >
   <Headline
     title={title}

--- a/src/components/widgets/Testimonials.astro
+++ b/src/components/widgets/Testimonials.astro
@@ -19,10 +19,11 @@ const {
   isDark = false,
   classes = {},
   bg = await Astro.slots.render("bg"),
+  noAnimation = false,
 } = Astro.props as Testimonials;
 ---
 
-<WidgetWrapper id={id} isDark={isDark} containerClass={`max-w-6xl mx-auto ${classes?.container ?? ""}`} bg={bg}>
+<WidgetWrapper id={id} isDark={isDark} containerClass={`max-w-6xl mx-auto ${classes?.container ?? ""}`} bg={bg} noAnimation={noAnimation} >
   <Headline title={title} subtitle={subtitle} tagline={tagline} />
 
   <div
@@ -41,7 +42,8 @@ const {
     {
       testimonials &&
         testimonials.map(({ title, testimonials, name, job, image }, index) => (
-          <div class="flex h-auto intersect-once motion-safe:md:intersect:animate-fade motion-safe:md:opacity-0 intersect-quarter">
+          <div class="flex h-auto no-intersect">
+          {/* <div class="flex h-auto intersect-once motion-safe:md:intersect:animate-fade motion-safe:md:opacity-0 intersect-quarter"> */}
             <div class="flex flex-col p-4 md:p-6 rounded-md shadow-xl dark:shadow-none border dark:border-neutral-600">
               {numbers && <p class="text-muted -mt-2 lg:-mt-4 lg:-ml-3">{index + 1}.</p>}
               {title && <h2 class="text-lg font-medium leading-6 pb-4">{title}</h2>}

--- a/src/pages/en/fivefold.astro
+++ b/src/pages/en/fivefold.astro
@@ -60,6 +60,7 @@ const t = useTranslations(lang);
   <!-- Content Widget **************** -->
 
   <Content
+    noAnimation={true}
     title={t("fivefold.content1.title")}
     subtitle={t("fivefold.content1.subtitle")}
     isReversed
@@ -128,6 +129,7 @@ const t = useTranslations(lang);
   <!-- Content Widget **************** -->
 
   <Content
+    noAnimation={true}
     title={t("fivefold.content2.title")}
     subtitle={t("fivefold.content2.subtitle")}
     whiteText={true}
@@ -204,6 +206,7 @@ const t = useTranslations(lang);
   <!-- Content Widget **************** -->
 
   <Content
+    noAnimation={true}
     title={t("fivefold.content3.title")}
     subtitle={t("fivefold.content3.subtitle")}
     isReversed
@@ -272,6 +275,7 @@ const t = useTranslations(lang);
   <!-- Content Widget **************** -->
 
   <Content
+    noAnimation={true}
     title={t("fivefold.content4.title")}
     subtitle={t("fivefold.content4.subtitle")}
     whiteText={true}
@@ -344,6 +348,7 @@ const t = useTranslations(lang);
   <!-- Content Widget **************** -->
 
   <Content
+    noAnimation={true}
     classes={{
       bottom: "border-b-0",
     }}

--- a/src/pages/en/witnesses.astro
+++ b/src/pages/en/witnesses.astro
@@ -53,6 +53,7 @@ const t = useTranslations(lang);
   <!-- Testimonials Widget *********** -->
 
   <Testimonials
+    noAnimation={true}
     title={t("witnesses.testimonials.title")}
     subtitle={t("witnesses.temp")}
     columns={2}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -98,6 +98,7 @@ export interface Widget {
   isDark?: boolean;
   bg?: string;
   classes?: Record<string, string>;
+  noAnimation?: boolean;
 }
 
 export interface Headline {


### PR DESCRIPTION
### TL;DR

Added ability to disable animations on widgets through a new `noAnimation` prop.

### What changed?

- Added `noAnimation` prop to `WidgetWrapper` component and related widget components
- Implemented conditional rendering of animation classes based on the `noAnimation` prop
- Disabled animations on the fivefold page content sections and witnesses testimonials

### How to test?

1. Navigate to the fivefold page and witnesses page
2. Verify that content sections no longer fade in on scroll
3. Check that other pages with animations still work as expected
4. Test with motion-safe and motion-reduce preferences to ensure proper behavior

### Why make this change?

The fade-in animations can be distracting on content-heavy pages where users need to focus on reading and understanding the material. Disabling animations on specific sections improves readability and user experience for these content-focused pages while maintaining the animated effects where they enhance the presentation.