### PR TITLE
fix: update lyrics panel init and dark mode background color

### DIFF
--- a/src/components/widgets/Lyrics.astro
+++ b/src/components/widgets/Lyrics.astro
@@ -3,7 +3,6 @@ import type { Widget } from "~/types";
 import WidgetWrapper from "~/components/ui/WidgetWrapper.astro";
 import Headline from "~/components/ui/Headline.astro";
 import { getLangFromUrl, useTranslations } from "~/i18n/utils";
-import { twMerge } from "tailwind-merge";
 
 // Define the interface for a single song with verses and chorus
 export interface Song {
@@ -64,7 +63,7 @@ const t = useTranslations(lang);
   <div id="lyrics-content" class="max-w-4xl xl:max-w-[896px] mx-auto">
     {
       songs.map((song, index) => (
-        <div id={`lyrics-${index}`} class={twMerge("lyrics-panel hidden", index === 0 ? "block" : "hidden")}>
+        <div id={`lyrics-${index}`} class="lyrics-panel hidden">
           <div class="bg-page rounded-lg p-8 xl:p-[24px] shadow-xl border border-gray-200 dark:border-gray-700">
             <h3
               class="text-2xl xl:text-3xl font-bold text-center mb-8 xl:mb-[24px] 
@@ -180,7 +179,7 @@ const t = useTranslations(lang);
           "border-gray-300",
           "dark:border-gray-600",
           "bg-white",
-          "dark:bg-gray-800",
+          "dark:bg-purple-900/40",
           "text-gray-700",
           "dark:text-gray-300"
         );


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated the Lyrics component styling for better dark mode appearance and fixed redundant class handling.

### What changed?
- Removed unnecessary `twMerge` import that was no longer needed
- Fixed redundant class assignment in lyrics panel div (removed duplicate hidden class)
- Changed dark mode background color from `dark:bg-gray-800` to `dark:bg-purple-900/40` for better contrast and visual appeal

## 📌 Additional Notes
The dark mode background now uses a semi-transparent purple shade which should provide better visual hierarchy and match the overall theme better.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing