### PR TITLE
fix: improve lyrics component initialization with retry mechanism

### DIFF
--- a/src/components/widgets/Lyrics.astro
+++ b/src/components/widgets/Lyrics.astro
@@ -191,13 +191,30 @@ const t = useTranslations(lang);
 
   // Initialize navigation when the DOM is ready and after each page navigation
   function initializeNavigation() {
+    // Use a small delay and retry mechanism to ensure elements are available
+    const trySetupLyrics = (attempts = 0) => {
+      const maxAttempts = 10;
+      const lyricsButtonsContainer = document.getElementById("lyrics-buttons");
+      const lyricsContentContainer = document.getElementById("lyrics-content");
+      
+      if (lyricsButtonsContainer && lyricsContentContainer) {
+        setupLyrics();
+      } else if (attempts < maxAttempts) {
+        // Retry after a short delay
+        setTimeout(() => trySetupLyrics(attempts + 1), 50);
+      }
+    };
+
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", setupLyrics);
+      document.addEventListener("DOMContentLoaded", () => trySetupLyrics());
     } else {
-      setupLyrics();
+      // Add a small delay to ensure elements are rendered
+      setTimeout(() => trySetupLyrics(), 10);
     }
   }
 
   initializeNavigation();
   document.addEventListener("astro:page-load", initializeNavigation);
+  // Also listen for astro:after-swap as a fallback
+  document.addEventListener("astro:after-swap", initializeNavigation);
 </script>


### PR DESCRIPTION
# Pull Request

## 📝 Description
Improved lyrics component initialization with retry mechanism for better reliability during page transitions

### What changed?
- Added a retry mechanism with timeout to ensure lyrics elements are available before setup
- Implemented a `trySetupLyrics` function that attempts to find required DOM elements up to 10 times
- Added small delays to ensure elements are fully rendered before initialization
- Added an event listener for `astro:after-swap` as a fallback to handle all possible page transition scenarios

## 📌 Additional Notes
This change addresses potential race conditions during page transitions where the lyrics component might try to initialize before its DOM elements are fully available.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🧪 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

## 📸 Screenshots