### PR TITLE
fix: simplify lyrics navigation initialization and add Zoom verification

### DIFF
--- a/src/components/widgets/Lyrics.astro
+++ b/src/components/widgets/Lyrics.astro
@@ -191,30 +191,13 @@ const t = useTranslations(lang);
 
   // Initialize navigation when the DOM is ready and after each page navigation
   function initializeNavigation() {
-    // Use a small delay and retry mechanism to ensure elements are available
-    const trySetupLyrics = (attempts = 0) => {
-      const maxAttempts = 10;
-      const lyricsButtonsContainer = document.getElementById("lyrics-buttons");
-      const lyricsContentContainer = document.getElementById("lyrics-content");
-      
-      if (lyricsButtonsContainer && lyricsContentContainer) {
-        setupLyrics();
-      } else if (attempts < maxAttempts) {
-        // Retry after a short delay
-        setTimeout(() => trySetupLyrics(attempts + 1), 50);
-      }
-    };
-
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", () => trySetupLyrics());
+      document.addEventListener("DOMContentLoaded", setupLyrics);
     } else {
-      // Add a small delay to ensure elements are rendered
-      setTimeout(() => trySetupLyrics(), 10);
+      setupLyrics();
     }
   }
 
   initializeNavigation();
   document.addEventListener("astro:page-load", initializeNavigation);
-  // Also listen for astro:after-swap as a fallback
-  document.addEventListener("astro:after-swap", initializeNavigation);
 </script>

--- a/src/pages/ZOOM_verify_FVyTtLKB6KNxG3Dqb7Cyb6.html
+++ b/src/pages/ZOOM_verify_FVyTtLKB6KNxG3Dqb7Cyb6.html
@@ -1,0 +1,1 @@
+ZOOM_verify_FVyTtLKB6KNxG3Dqb7Cyb6


### PR DESCRIPTION
# Pull Request

## 📝 Description
Simplifies the lyrics navigation initialization and adds Zoom verification file

### What changed?
- Removed the retry mechanism in the lyrics navigation initialization
- Simplified the event listener setup by directly calling `setupLyrics()`
- Removed the `astro:after-swap` event listener as it's no longer needed
- Added Zoom verification file for domain verification

## 📌 Additional Notes
The previous implementation used a complex retry mechanism with delays and multiple attempts to ensure elements were available. The new approach is more straightforward and relies on the standard DOM ready events.

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing