### PR TITLE
fix: update Prayer Church URL and Zoom meeting links

### DIFF
--- a/src/components/widgets/Footer.astro
+++ b/src/components/widgets/Footer.astro
@@ -45,7 +45,7 @@ const socialLinks = [
   },
   {
     ariaLabel: t("footer.prayerChurch"),
-    href: "https://prayerchurch.com",
+    href: "https://rukouksenseurakunta.fi",
     image: {
       src: prayerChurchLogo,
       alt: "PrayerChurch",

--- a/src/pages/en/events.astro
+++ b/src/pages/en/events.astro
@@ -91,7 +91,7 @@ const songs = [
         description: t("events.features.items1.description"),
         description2: {
           text: t("events.features.items1.description2"),
-          link: "https://uef.zoom.us/j/62720309361?pwd=MDBOdUc0RHFMVmt3bHZXR1FHL2swUT09",
+          link: "https://flamethefreeze.zoom.us/j/89840579351?pwd=Hr5ZAcJHbUVrybCIIySL6sT6Vw7Rly.1",
         },
         icon: "tabler:book",
       },
@@ -100,7 +100,7 @@ const songs = [
         description: t("events.features.items2.description"),
         description2: {
           text: t("events.features.items2.description2"),
-          link: "https://uef.zoom.us/j/64440694917?pwd=eUxZRlUyM00vNkxseW1rcGxlZTc3UT09",
+          link: "https://flamethefreeze.zoom.us/j/82297139976?pwd=2ZCDgn6UVPyuqKeKsh8CWBN3IQhiXu.1",
         },
         icon: "tabler:pray",
       },


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated external links in the website to reflect new domains and meeting URLs.

### What changed?
- Changed Prayer Church link in the footer from `prayerchurch.com` to `rukouksenseurakunta.fi`
- Updated Zoom meeting links for events:
  - Changed the first Zoom link from UEF domain to FlameTheFreeze domain
  - Changed the second Zoom link from UEF domain to FlameTheFreeze domain

## 📌 Additional Notes
These updates ensure users are directed to the correct and current external resources.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing