### PR TITLE
refactor: remove redundant theme scripts and update menu colors

### DIFF
--- a/src/components/common/BasicScripts.astro
+++ b/src/components/common/BasicScripts.astro
@@ -2,7 +2,7 @@
 
 ---
 
-<script is:inline>
+<script is:inline define:vars={{}}>
   if (window.basic_script) {
     return;
   }
@@ -123,12 +123,6 @@
 
   window.onload = onLoad;
   window.onpageshow = onPageShow;
-
-  // Handle Astro View Transitions
-  document.addEventListener("astro:before-swap", () => {
-    // Store current theme before transition
-    window.currentTheme = getThemePreference();
-  });
 
   document.addEventListener("astro:after-swap", () => {
     // Restore theme after transition

--- a/src/components/common/ToggleMenu.astro
+++ b/src/components/common/ToggleMenu.astro
@@ -15,15 +15,15 @@ const {
   <slot>
     <span
       aria-hidden="true"
-      class="h-[3px] w-6 my-[3px] rounded-full bg-black dark:bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:rotate-45 group-[.expanded]:translate-y-2.5"
+      class="h-[3px] w-6 my-[3px] rounded-full bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:rotate-45 group-[.expanded]:translate-y-2.5"
     ></span>
     <span
       aria-hidden="true"
-      class="h-[3px] w-6 my-[3px] rounded-full bg-black dark:bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:opacity-0"
+      class="h-[3px] w-6 my-[3px] rounded-full bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:opacity-0"
     ></span>
     <span
       aria-hidden="true"
-      class="h-[3px] w-6 my-[3px] rounded-full bg-black dark:bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:-rotate-45 group-[.expanded]:-translate-y-2"
+      class="h-[3px] w-6 my-[3px] rounded-full bg-white transition ease transform duration-200 opacity-80 group-[.expanded]:-rotate-45 group-[.expanded]:-translate-y-2"
     ></span>
   </slot>
 </button>


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fixed theme handling in navigation menu and optimized script loading

### What changed?
- Added `define:vars={{}}` to the inline script in BasicScripts.astro
- Removed the "astro:before-swap" event listener that was storing the current theme before transition
- Changed the hamburger menu color from conditional dark/light mode to always white

## 📌 Additional Notes
The menu toggle now consistently uses white color for better visibility, and the theme handling during page transitions has been simplified.

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Style/UI update
- [x] ♻️ Code refactoring

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing