### PR TITLE
fix: improve video autoplay compatibility for Safari browsers

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,9 +43,11 @@ const metadata = {
       aria-label="fire of god and fire for god fire background"
       class="absolute inset-0 w-full h-full object-cover z-0 opacity-0 transition-opacity duration-1000 ease-in-out"
       data-src={`${ENDPOINTS.publicFiles}/fire_of_god_and_fire_for_god-fire_bg.mp4`}
+      autoplay
       loop
       muted
-      preload="none"
+      playsinline
+      preload="metadata"
     >
       Your browser does not support the video tag.
     </video>
@@ -310,10 +312,32 @@ const metadata = {
             heroGradient.classList.remove("opacity-0");
             heroGradient.classList.add("opacity-100");
 
-            // Start playing the video
-            heroVideo.play().catch((error) => {
-              console.log("Video autoplay failed:", error);
-            });
+            // Start playing the video with Safari-specific handling
+            const playPromise = heroVideo.play();
+            
+            if (playPromise !== undefined) {
+              playPromise
+                .then(() => {
+                  console.log("Video autoplay started successfully");
+                })
+                .catch((error) => {
+                  console.log("Video autoplay failed:", error);
+                  // For Safari, try to play on user interaction
+                  if (error.name === 'NotAllowedError') {
+                    console.log("Autoplay blocked - will attempt to play on user interaction");
+                    // Add click listener to start video on first user interaction
+                    const startVideoOnInteraction = () => {
+                      heroVideo.play().then(() => {
+                        console.log("Video started after user interaction");
+                      }).catch(console.error);
+                      document.removeEventListener('click', startVideoOnInteraction);
+                      document.removeEventListener('touchstart', startVideoOnInteraction);
+                    };
+                    document.addEventListener('click', startVideoOnInteraction, { once: true });
+                    document.addEventListener('touchstart', startVideoOnInteraction, { once: true });
+                  }
+                });
+            }
 
             // Remove the event listener as it's no longer needed
             heroVideo.removeEventListener("loadeddata", handleVideoLoaded);


### PR DESCRIPTION
# Pull Request

## 📝 Description
Improved video autoplay behavior on the homepage, particularly for Safari browsers.

### What changed?
- Added `autoplay` and `playsinline` attributes to the hero video element
- Changed video preload attribute from "none" to "metadata" for better loading performance
- Implemented Safari-specific error handling for autoplay restrictions
- Added fallback mechanism to start video playback on first user interaction (click/touch) when autoplay is blocked

## 📌 Additional Notes
This change addresses autoplay issues in Safari where videos with autoplay are often blocked by default. The implementation now gracefully degrades by attaching event listeners that will start the video on the first user interaction.

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing