### PR TITLE
fix: optimize video loading by setting preload to "none" initially

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,7 +47,7 @@ const metadata = {
       loop
       muted
       playsinline
-      preload="metadata"
+      preload="none"
     >
       Your browser does not support the video tag.
     </video>
@@ -301,6 +301,8 @@ const metadata = {
 
           if (videoSrc && !heroVideo.src) {
             heroVideo.src = videoSrc;
+            // Set preload to metadata now that we're ready to load
+            heroVideo.preload = "metadata";
             heroVideo.load(); // Ensure the video loads properly
           }
 


### PR DESCRIPTION
# Pull Request

## 📝 Description
Optimize video loading by initially setting preload to "none" and dynamically changing to "metadata" only when needed

### What changed?
- Changed initial video preload attribute from "metadata" to "none" to prevent unnecessary loading
- Added code to set preload to "metadata" only when the video source is ready to be loaded
- This improves initial page load performance by deferring video loading until actually needed

## 📌 Additional Notes
This change helps reduce initial bandwidth usage and improves page load times, especially on slower connections.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Style/UI update
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing