### PR TITLE
chore: update rebuild progress from 2/18 to 3/18

### DIFF
--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -13,7 +13,7 @@ export interface Props {
 
 const {
   lang = "en",
-  rebuildProgress = { current: 2, total: 18 },
+  rebuildProgress = { current: 3, total: 18 },
   siteRebuildStatus = { status: "notStarted", display: true },
 } = Astro.props;
 


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated the rebuild progress counter from 2/18 to 3/18 in the Announcement component.

### What changed?
- Incremented the `current` value in the `rebuildProgress` default prop from 2 to 3, indicating progress in the site rebuild process

## 📌 Additional Notes
This change reflects the latest progress in the site rebuild effort.

## 🔗 Related Issues
🔄 Closes #
- 

## 🔍 Type of Change
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Adjusted the default rebuild progress shown in the Announcement widget from 2/18 (11%) to 3/18 (17%), making the progress bar and percentage appear slightly further along when no progress is provided by the page. No impact when explicit progress is supplied; existing functionality remains unchanged. This affects only the initial visual state. Users will see a modestly higher default completion on first load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->