### PR TITLE
fix: add periods to word items subtitles and adjust content padding

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -245,11 +245,11 @@ export const ui = {
     "word.hero.subtitle.1": "Does you words have power? Know how you can receive the power of the words in your life.",
     "word.hero.cta.button": "I want the power of the words in my life ✋",
     "word.wordItems.title.1": "Speak less",
-    "word.wordItems.subtitle.1": "Practical: Study to be quiet",
+    "word.wordItems.subtitle.1": "Practical: Study to be quiet.",
     "word.wordItems.description.1":
       "Even a fool is counted wise if he keeps quiet: and he that simply shuts his lips is esteemed a man of understanding.🧐🤐 <br/><br/>On the other hand you can distinguish a fool from many words: and in the multitude of the words sin will not be lacking 🤬👿",
     "word.wordItems.title.2": "Listen before you speak",
-    "word.wordItems.subtitle.2": "Practical: Be the last person to speak",
+    "word.wordItems.subtitle.2": "Practical: Be the last person to speak.",
     "word.wordItems.description.2":
       "Don’t rush to be the first one to speak. Practice patience, listen to others first, and then share your thoughts clearly.🥈🥉😗 <br/><br/>When you listen first, you gain their key points and conclusions — and your reply becomes better, and smarter.🆓☝️",
     "word.wordItems.title.3": "Speak with purpose",

--- a/src/screens/word.astro
+++ b/src/screens/word.astro
@@ -200,7 +200,7 @@ const wordItems = [
                 </div>
 
                 <!-- Content -->
-                <div class="relative p-8 xl:p-[32px] h-full flex flex-col">
+                <div class="relative p-4 lg:p-8 xl:p-[32px] h-full flex flex-col">
                   <!-- Text content -->
                   <div class="relative text-center">
                     <span


### PR DESCRIPTION
# Pull Request

## 📝 Description
Added punctuation to word item subtitles and improved responsive padding for content containers.

### What changed?
- Added missing periods to "Study to be quiet" and "Be the last person to speak" subtitles
- Adjusted padding in word.astro content div to be more responsive with different values for mobile, tablet, and desktop views (p-4 for mobile, lg:p-8 for tablet, xl:p-[32px] for desktop)

## 📌 Additional Notes
These changes improve text consistency and enhance the responsive layout across different device sizes.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing