### PR TITLE
fix: remove conditional href logic in LanguagePicker

### DIFF
--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -9,7 +9,7 @@ const currentPath = Astro.url.pathname;
 
 <div class="flex items-center gap-1">
   <a
-    href={lang === "en" ? undefined : changeLangInUrl(currentPath, "en")}
+    href={changeLangInUrl(currentPath, "en")}
     class={twMerge(
       "p-2.5 rounded-lg transition-all duration-300 ease-in-out",
       "focus:outline-none focus:scale-110",
@@ -21,7 +21,7 @@ const currentPath = Astro.url.pathname;
     <span class="text-2xl">🇺🇸</span>
   </a>
   <a
-    href={lang === "fi" ? undefined : changeLangInUrl(currentPath, "fi")}
+    href={changeLangInUrl(currentPath, "fi")}
     class={twMerge(
       "p-2.5 rounded-lg transition-all duration-300 ease-in-out",
       "focus:outline-none focus:scale-110",


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fix language picker links to always use the `changeLangInUrl` function regardless of current language

### What changed?
- Removed conditional logic that was preventing links from being generated when the user was already on the selected language
- Now the language picker always generates links for both English and Finnish options

## 📌 Additional Notes
This ensures consistent behavior in the language picker component and allows users to refresh the current language page if needed.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing