### PR TITLE
fix: add fallback URLs to language picker links

### DIFF
--- a/src/components/common/LanguagePicker.astro
+++ b/src/components/common/LanguagePicker.astro
@@ -9,7 +9,7 @@ const currentPath = Astro.url.pathname;
 
 <div class="flex items-center gap-1">
   <a
-    href={changeLangInUrl(currentPath, "en")}
+    href={changeLangInUrl(currentPath, "en") || "/"}
     class={twMerge(
       "p-2.5 rounded-lg transition-all duration-300 ease-in-out",
       "focus:outline-none focus:scale-110",
@@ -21,7 +21,7 @@ const currentPath = Astro.url.pathname;
     <span class="text-2xl">🇺🇸</span>
   </a>
   <a
-    href={changeLangInUrl(currentPath, "fi")}
+    href={changeLangInUrl(currentPath, "fi") || "/jumalan-tuli"}
     class={twMerge(
       "p-2.5 rounded-lg transition-all duration-300 ease-in-out",
       "focus:outline-none focus:scale-110",


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fix language picker fallback URLs to ensure proper navigation when changing languages.

### What changed?
- Updated the English language link to fallback to the root URL (`/`) when `changeLangInUrl()` returns a falsy value
- Updated the Finnish language link to fallback to `/jumalan-tuli` when `changeLangInUrl()` returns a falsy value

## 📌 Additional Notes
This ensures users can always navigate between language versions even when on pages that don't have direct translations.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the language picker by adding fallbacks to prevent broken or empty links.
  * English now defaults to the homepage when the current path can’t be converted.
  * Finnish now defaults to the “Jumalan tuli” page when conversion fails.
  * Ensures consistent, functional language switching across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->